### PR TITLE
Create a separate RTCDataChannel for signalling

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,32 @@
+name: Publish npm package to gitea
+on:
+  release:
+    types: [published]
+jobs:
+  npm_publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 16.x ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - name: Run npm build
+        run: |
+          npm run build
+      - name: Configure git.vdb.to npm registry
+        run: |
+          npm config set registry https://git.vdb.to/api/packages/cerc-io/npm/
+      - name: Authenticate to git.vdb.to registry
+        run: |
+          npm config set -- '//git.vdb.to/api/packages/cerc-io/npm/:_authToken' "${{ secrets.GITEA_PUBLISH_TOKEN }}"
+      - name: npm publish
+        run: |
+          npm publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@libp2p/webrtc-peer",
-  "version": "2.0.2",
+  "name": "@cerc-io/webrtc-peer",
+  "version": "2.0.2-laconic-0.1.0",
   "description": "Simple one-to-one WebRTC data channels",
   "author": "",
   "license": "Apache-2.0 OR MIT",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   },
   "devDependencies": {
     "@mapbox/node-pre-gyp": "^1.0.8",
-    "aegir": "^37.2.0",
+    "aegir": "^38.1.0",
     "it-first": "^2.0.0",
     "it-pipe": "^2.0.3",
     "wherearewe": "^2.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ export interface WebRTCInitiatorInit extends WebRTCPeerInit {
   dataChannelLabel?: string
   dataChannelInit?: RTCDataChannelInit
   offerOptions?: RTCOfferOptions
-  createSignallingChannel: boolean
 }
 
 export interface OfferSignal {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export interface WebRTCPeerEvents {
   'close': CustomEvent
   'ice-candidate': CustomEvent
   'error': CustomEvent<Error>
+  'signalling-channel': CustomEvent
 }
 
 export { WebRTCReceiver } from './receiver.js'
@@ -30,6 +31,7 @@ export interface WebRTCInitiatorInit extends WebRTCPeerInit {
   dataChannelLabel?: string
   dataChannelInit?: RTCDataChannelInit
   offerOptions?: RTCOfferOptions
+  createSignallingChannel: boolean
 }
 
 export interface OfferSignal {
@@ -60,3 +62,6 @@ export interface GoodbyeSignal {
 }
 
 export type Signal = OfferSignal | AnswerSignal | CandidateSignal | RenegotiateSignal | GoodbyeSignal
+
+export const SIGNAL_LABEL = 'SIGNAL_LABEL'
+export const SIGNAL_PROTOCOL = '/signal/1.0.0'

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export interface WebRTCPeerEvents {
   'close': CustomEvent
   'ice-candidate': CustomEvent
   'error': CustomEvent<Error>
-  'signalling-channel': CustomEvent
+  'signalling-channel': CustomEvent<RTCDataChannel>
 }
 
 export { WebRTCReceiver } from './receiver.js'

--- a/src/initiator.ts
+++ b/src/initiator.ts
@@ -22,12 +22,15 @@ export class WebRTCInitiator extends WebRTCPeer {
       logPrefix: 'initiator'
     })
 
-    this.handleDataChannelEvent({
-      channel: this.peerConnection.createDataChannel(
+    try {
+      const channel = this.peerConnection.createDataChannel(
         opts.dataChannelLabel ?? uint8ArrayToString(randombytes(20), 'hex').slice(0, 7),
         opts.dataChannelInit
       )
-    })
+      this.handleDataChannelEvent({ channel })
+    } catch (err) {
+      this.log('error creating a RTCDataChannel %s', err)
+    }
 
     this.handshake = new WebRTCInitiatorHandshake({
       log: this.log,
@@ -47,12 +50,15 @@ export class WebRTCInitiator extends WebRTCPeer {
   }
 
   createSignallingChannel () {
-    this.handleSignallingDataChannelEvent({
-      channel: this.peerConnection.createDataChannel(
+    try {
+      const channel = this.peerConnection.createDataChannel(
         SIGNAL_LABEL,
         { protocol: SIGNAL_PROTOCOL }
       )
-    })
+      this.handleSignallingDataChannelEvent({ channel })
+    } catch (err) {
+      this.log('error creating a signalling RTCDataChannel %s', err)
+    }
   }
 }
 

--- a/src/initiator.ts
+++ b/src/initiator.ts
@@ -31,12 +31,7 @@ export class WebRTCInitiator extends WebRTCPeer {
 
     // Create a signalling channel only if requested
     if (opts.createSignallingChannel) {
-      this.handleSignallingDataChannelEvent({
-        channel: this.peerConnection.createDataChannel(
-          SIGNAL_LABEL,
-          { protocol: SIGNAL_PROTOCOL }
-        )
-      })
+      this.createSignallingChannel()
     }
 
     this.handshake = new WebRTCInitiatorHandshake({
@@ -53,6 +48,15 @@ export class WebRTCInitiator extends WebRTCPeer {
   handleSignal (signal: Signal) {
     this.handshake.handleSignal(signal).catch(err => {
       this.log('error handling signal %o %o', signal, err)
+    })
+  }
+
+  createSignallingChannel () {
+    this.handleSignallingDataChannelEvent({
+      channel: this.peerConnection.createDataChannel(
+        SIGNAL_LABEL,
+        { protocol: SIGNAL_PROTOCOL }
+      )
     })
   }
 }

--- a/src/initiator.ts
+++ b/src/initiator.ts
@@ -16,7 +16,7 @@ const ICECOMPLETE_TIMEOUT = 1000
 export class WebRTCInitiator extends WebRTCPeer {
   private readonly handshake: WebRTCInitiatorHandshake
 
-  constructor (opts: WebRTCInitiatorInit = { createSignallingChannel: false }) {
+  constructor (opts: WebRTCInitiatorInit = {}) {
     super({
       ...opts,
       logPrefix: 'initiator'
@@ -28,11 +28,6 @@ export class WebRTCInitiator extends WebRTCPeer {
         opts.dataChannelInit
       )
     })
-
-    // Create a signalling channel only if requested
-    if (opts.createSignallingChannel) {
-      this.createSignallingChannel()
-    }
 
     this.handshake = new WebRTCInitiatorHandshake({
       log: this.log,

--- a/src/initiator.ts
+++ b/src/initiator.ts
@@ -29,7 +29,10 @@ export class WebRTCInitiator extends WebRTCPeer {
       )
       this.handleDataChannelEvent({ channel })
     } catch (err) {
-      this.log('error creating a RTCDataChannel %s', err)
+      const errMsg = `error creating a RTCDataChannel ${err}`
+      this.log(errMsg)
+
+      throw new Error(errMsg)
     }
 
     this.handshake = new WebRTCInitiatorHandshake({
@@ -57,7 +60,10 @@ export class WebRTCInitiator extends WebRTCPeer {
       )
       this.handleSignallingDataChannelEvent({ channel })
     } catch (err) {
-      this.log('error creating a signalling RTCDataChannel %s', err)
+      const errMsg = `error creating a signalling RTCDataChannel ${err}`
+      this.log(errMsg)
+
+      throw new Error(errMsg)
     }
   }
 }

--- a/src/initiator.ts
+++ b/src/initiator.ts
@@ -7,7 +7,7 @@ import delay from 'delay'
 import { CustomEvent } from '@libp2p/interfaces/events'
 import { logger } from '@libp2p/logger'
 import type { WebRTCHandshakeOptions } from './handshake.js'
-import type { WebRTCInitiatorInit, AnswerSignal, Signal } from './index.js'
+import { WebRTCInitiatorInit, AnswerSignal, Signal, SIGNAL_LABEL, SIGNAL_PROTOCOL } from './index.js'
 
 const log = logger('libp2p:webrtc-peer:initator')
 
@@ -16,7 +16,7 @@ const ICECOMPLETE_TIMEOUT = 1000
 export class WebRTCInitiator extends WebRTCPeer {
   private readonly handshake: WebRTCInitiatorHandshake
 
-  constructor (opts: WebRTCInitiatorInit = {}) {
+  constructor (opts: WebRTCInitiatorInit = { createSignallingChannel: false }) {
     super({
       ...opts,
       logPrefix: 'initiator'
@@ -28,6 +28,16 @@ export class WebRTCInitiator extends WebRTCPeer {
         opts.dataChannelInit
       )
     })
+
+    // Create a signalling channel only if requested
+    if (opts.createSignallingChannel) {
+      this.handleSignallingDataChannelEvent({
+        channel: this.peerConnection.createDataChannel(
+          SIGNAL_LABEL,
+          { protocol: SIGNAL_PROTOCOL }
+        )
+      })
+    }
 
     this.handshake = new WebRTCInitiatorHandshake({
       log: this.log,

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -47,6 +47,8 @@ export class WebRTCPeer extends EventEmitter<WebRTCPeerEvents> implements Duplex
   public source: Pushable<Uint8Array>
   public sink: Sink<Uint8Array>
   public closed: boolean
+  public signallingChannel?: RTCDataChannel
+
   protected wrtc: WRTC
   protected peerConnection: RTCPeerConnection
   protected channel?: WebRTCDataChannel
@@ -82,7 +84,7 @@ export class WebRTCPeer extends EventEmitter<WebRTCPeerEvents> implements Duplex
     }
   }
 
-  protected handleDataChannelEvent (event: { channel?: RTCDataChannel}) {
+  protected handleDataChannelEvent (event: { channel?: RTCDataChannel }) {
     const dataChannel = event.channel
 
     if (dataChannel == null) {
@@ -119,6 +121,10 @@ export class WebRTCPeer extends EventEmitter<WebRTCPeerEvents> implements Duplex
     })
   }
 
+  handleSignallingDataChannelEvent (event: { channel?: RTCDataChannel }) {
+    this.signallingChannel = event.channel
+  }
+
   async close (err?: Error) {
     this.closed = true
 
@@ -130,6 +136,7 @@ export class WebRTCPeer extends EventEmitter<WebRTCPeerEvents> implements Duplex
     }
 
     this.channel?.close()
+    this.signallingChannel?.close()
     this.peerConnection.close()
     this.source.end(err)
     this.dispatchEvent(new CustomEvent('close'))

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -123,6 +123,10 @@ export class WebRTCPeer extends EventEmitter<WebRTCPeerEvents> implements Duplex
 
   handleSignallingDataChannelEvent (event: { channel?: RTCDataChannel }) {
     this.signallingChannel = event.channel
+
+    this.dispatchEvent(new CustomEvent<RTCDataChannel>('signalling-channel', {
+      detail: this.signallingChannel
+    }));
   }
 
   async close (err?: Error) {

--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -30,9 +30,6 @@ export class WebRTCReceiver extends WebRTCPeer {
       const newChannel = event.channel
       if (newChannel.label === SIGNAL_LABEL || newChannel.protocol === SIGNAL_PROTOCOL) {
         this.handleSignallingDataChannelEvent(event)
-        this.dispatchEvent(new CustomEvent<RTCDataChannel>('signalling-channel', {
-          detail: newChannel
-        }));
       } else {
         this.handleDataChannelEvent(event)
       }

--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -30,7 +30,9 @@ export class WebRTCReceiver extends WebRTCPeer {
       const newChannel = event.channel
       if (newChannel.label === SIGNAL_LABEL || newChannel.protocol === SIGNAL_PROTOCOL) {
         this.handleSignallingDataChannelEvent(event)
-        this.dispatchEvent(new CustomEvent('signalling-channel'))
+        this.dispatchEvent(new CustomEvent<RTCDataChannel>('signalling-channel', {
+          detail: newChannel
+        }));
       } else {
         this.handleDataChannelEvent(event)
       }

--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -3,7 +3,7 @@ import { WebRTCHandshake } from './handshake.js'
 import { CustomEvent } from '@libp2p/interfaces/events'
 import { logger } from '@libp2p/logger'
 import type { WebRTCHandshakeOptions } from './handshake.js'
-import type { WebRTCReceiverInit, OfferSignal, Signal, CandidateSignal } from './index.js'
+import { WebRTCReceiverInit, OfferSignal, Signal, CandidateSignal, SIGNAL_LABEL, SIGNAL_PROTOCOL } from './index.js'
 
 const log = logger('libp2p:webrtc-peer:receiver')
 
@@ -27,7 +27,13 @@ export class WebRTCReceiver extends WebRTCPeer {
       detail: event.detail
     })))
     this.peerConnection.addEventListener('datachannel', (event) => {
-      this.handleDataChannelEvent(event)
+      const newChannel = event.channel
+      if (newChannel.label === SIGNAL_LABEL || newChannel.protocol === SIGNAL_PROTOCOL) {
+        this.handleSignallingDataChannelEvent(event)
+        this.dispatchEvent(new CustomEvent('signalling-channel'))
+      } else {
+        this.handleDataChannelEvent(event)
+      }
     })
   }
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289

- Add support for a new RTCDataChannel for peer signalling in `cerc-io/webrtc-direct` transport
- Scope the package under `cerc-io` and add a workflow to publish it