### PR TITLE
Set binary type for signalling channel

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -4,6 +4,7 @@ import type { Logger } from '@libp2p/logger'
 
 const MAX_BUFFERED_AMOUNT = 64 * 1024
 const CHANNEL_CLOSING_TIMEOUT = 5 * 1000
+export const CHANNEL_BINARY_TYPE = 'arraybuffer'
 
 export interface WebRTCDataChannelOptions {
   onMessage: (event: MessageEvent<Uint8Array>) => void
@@ -24,7 +25,7 @@ export class WebRTCDataChannel {
     this.label = channel.label
     this.open = defer()
     this.channel = channel
-    this.channel.binaryType = 'arraybuffer'
+    this.channel.binaryType = CHANNEL_BINARY_TYPE
     this.log = opts.log
 
     if (typeof this.channel.bufferedAmountLowThreshold === 'number') {

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -5,7 +5,7 @@ import randombytes from 'iso-random-stream/src/random.js'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { Pushable, pushable } from 'it-pushable'
 import defer, { DeferredPromise } from 'p-defer'
-import { WebRTCDataChannel } from './channel.js'
+import { WebRTCDataChannel, CHANNEL_BINARY_TYPE } from './channel.js'
 import delay from 'delay'
 import type { WebRTCPeerInit, WebRTCPeerEvents, WRTC } from './index.js'
 import type { Duplex, Sink } from 'it-stream-types'
@@ -121,8 +121,9 @@ export class WebRTCPeer extends EventEmitter<WebRTCPeerEvents> implements Duplex
     })
   }
 
-  handleSignallingDataChannelEvent (event: { channel?: RTCDataChannel }) {
+  handleSignallingDataChannelEvent (event: { channel: RTCDataChannel }) {
     this.signallingChannel = event.channel
+    this.signallingChannel.binaryType = CHANNEL_BINARY_TYPE
 
     this.dispatchEvent(new CustomEvent<RTCDataChannel>('signalling-channel', {
       detail: this.signallingChannel


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289

- Set binary type to `arraybuffer` for signalling channel as done for regular datachannel
  - With Firefox browser, not setting it results in empty data on receiver end of the RTCDataChannel channel