### PR TITLE
Add an option to set the port range for webrtc connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/webrtc-peer",
-  "version": "2.0.2-laconic-0.1.3",
+  "version": "2.0.2-laconic-0.1.4",
   "description": "Simple one-to-one WebRTC data channels",
   "author": "",
   "license": "Apache-2.0 OR MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ export interface WebRTCPeerInit {
   id?: string
   wrtc?: WRTC
   peerConnectionConfig?: RTCConfiguration
+  webRTCPortRange?: {
+    min: number
+    max: number
+  }
 }
 
 export interface WebRTCReceiverInit extends WebRTCPeerInit {

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -62,7 +62,7 @@ export class WebRTCPeer extends EventEmitter<WebRTCPeerEvents> implements Duplex
     this.log = logger(`libp2p:webrtc-peer:${opts.logPrefix}:${this.id}`)
     this.wrtc = opts.wrtc ?? getBrowserRTC()
     this.peerConnection = new this.wrtc.RTCPeerConnection(
-      Object.assign({}, DEFAULT_PEER_CONNECTION_CONFIG, opts.peerConnectionConfig)
+      Object.assign({ portRange: opts.webRTCPortRange }, DEFAULT_PEER_CONNECTION_CONFIG, opts.peerConnectionConfig)
     )
     this.closed = false
     this.connected = defer()


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289
